### PR TITLE
failed nbest 4-gram

### DIFF
--- a/egs/librispeech/asr/simple_v1/run.sh
+++ b/egs/librispeech/asr/simple_v1/run.sh
@@ -83,24 +83,36 @@ if [ $stage -le 7 ]; then
   ln -sf /ceph-ly/open-source/to_submit/espnet_snowfall/snowfall/egs/librispeech/asr/simple_v1/data ./
   output_dir=result_dir
   mkdir -p $output_dir
+  # no rescore
+  python3 ./mmi_att_transformer_decode.py \
+    --output-dir $output_dir \
+    --num-paths -1 \
+    --max-duration 300 \
+    --attention-dim 512 \
+    --use-lm-rescoring False \
+    --avg 16 \
+    --epoch 19
+
+  # lattice rescore
   python3 ./mmi_att_transformer_decode.py \
     --output-dir $output_dir \
     --num-paths -1 \
     --max-duration 300 \
     --attention-dim 512 \
     --use-lm-rescoring True \
-    --avg 15 \
+    --avg 16 \
     --epoch 19
 fi
 
 if [ $stage -le 8 ]; then
   export CUDA_VISIBLE_DEVICES=3
+  # nbest rescore
   python3 ./mmi_att_transformer_decode.py \
     --output-dir $output_dir \
     --num-paths 1000 \
     --max-duration 300 \
     --attention-dim 512 \
     --use-lm-rescoring True \
-    --avg 15 \
+    --avg 16 \
     --epoch 19
 fi

--- a/snowfall/models/conformer.py
+++ b/snowfall/models/conformer.py
@@ -36,7 +36,8 @@ class Conformer(Transformer):
                  d_model: int = 256, nhead: int = 4, dim_feedforward: int = 2048,
                  num_encoder_layers: int = 12, num_decoder_layers: int = 6,
                  dropout: float = 0.1, cnn_module_kernel: int = 31,
-                 normalize_before: bool = True, vgg_frontend: bool = False) -> None:
+                 normalize_before: bool = True, vgg_frontend: bool = False,
+                 is_espnet_structure: bool = False) -> None:
         super(Conformer, self).__init__(num_features=num_features, num_classes=num_classes, subsampling_factor=subsampling_factor,
                  d_model=d_model, nhead=nhead, dim_feedforward=dim_feedforward,
                  num_encoder_layers=num_encoder_layers, num_decoder_layers=num_decoder_layers,
@@ -44,8 +45,12 @@ class Conformer(Transformer):
 
         self.encoder_pos = RelPositionalEncoding(d_model, dropout)
 
-        encoder_layer = ConformerEncoderLayer(d_model, nhead, dim_feedforward, dropout, cnn_module_kernel, normalize_before)
+        encoder_layer = ConformerEncoderLayer(d_model, nhead, dim_feedforward, dropout, cnn_module_kernel, normalize_before, is_espnet_structure)
         self.encoder = ConformerEncoder(encoder_layer, num_encoder_layers)
+        self.normalize_before = normalize_before
+        self.is_espnet_structure = is_espnet_structure
+        if self.normalize_before and self.is_espnet_structure:
+            self.after_norm = nn.LayerNorm(d_model)
 
     def encode(self, x: Tensor, supervisions: Optional[Dict] = None) -> Tuple[Tensor, Optional[Tensor]]:
         """
@@ -65,6 +70,8 @@ class Conformer(Transformer):
         mask = encoder_padding_mask(x.size(0), supervisions)
         mask = mask.to(x.device) if mask != None else None
         x = self.encoder(x, pos_emb, src_key_padding_mask=mask)  # (T, B, F)
+        if self.normalize_before and self.is_espnet_structure:
+            x = self.after_norm(x)
 
         return x, mask
 
@@ -90,9 +97,10 @@ class ConformerEncoderLayer(nn.Module):
     """
 
     def __init__(self, d_model: int, nhead: int, dim_feedforward: int = 2048, dropout: float = 0.1,
-                 cnn_module_kernel: int = 31, normalize_before: bool = True) -> None:
+                 cnn_module_kernel: int = 31, normalize_before: bool = True,
+                 is_espnet_structure=False) -> None:
         super(ConformerEncoderLayer, self).__init__()
-        self.self_attn = RelPositionMultiheadAttention(d_model, nhead, dropout=0.0)
+        self.self_attn = RelPositionMultiheadAttention(d_model, nhead, dropout=0.0, is_espnet_structure=is_espnet_structure)
 
         self.feed_forward = nn.Sequential(
             nn.Linear(d_model, dim_feedforward),
@@ -319,7 +327,8 @@ class RelPositionMultiheadAttention(nn.Module):
         >>> attn_output, attn_output_weights = multihead_attn(query, key, value, pos_emb)
     """
 
-    def __init__(self, embed_dim: int, num_heads: int, dropout: float = 0.) -> None:
+    def __init__(self, embed_dim: int, num_heads: int, dropout: float = 0.,
+            is_espnet_structure: bool = False) -> None:
         super(RelPositionMultiheadAttention, self).__init__()
         self.embed_dim = embed_dim
         self.num_heads = num_heads
@@ -338,6 +347,7 @@ class RelPositionMultiheadAttention(nn.Module):
         self.pos_bias_v = nn.Parameter(torch.Tensor(num_heads, self.head_dim))
 
         self._reset_parameters()
+        self.is_espnet_structure = is_espnet_structure
 
     def _reset_parameters(self) -> None:
         nn.init.xavier_uniform_(self.in_proj.weight)
@@ -538,7 +548,8 @@ class RelPositionMultiheadAttention(nn.Module):
                 _b = _b[_start:]
             v = nn.functional.linear(value, _w, _b)
 
-        q = q * scaling
+        if not self.is_espnet_structure:
+            q = q * scaling
 
         if attn_mask is not None:
             assert attn_mask.dtype == torch.float32 or attn_mask.dtype == torch.float64 or \
@@ -596,7 +607,10 @@ class RelPositionMultiheadAttention(nn.Module):
         matrix_bd = torch.matmul(q_with_bias_v, p.transpose(-2, -1)) # (batch, head, time1, 2*time1-1)
         matrix_bd = self.rel_shift(matrix_bd)
 
-        attn_output_weights = (matrix_ac + matrix_bd)  # (batch, head, time1, time2)
+        if not self.is_espnet_structure:
+            attn_output_weights = (matrix_ac + matrix_bd)  # (batch, head, time1, time2)
+        else:
+            attn_output_weights = (matrix_ac + matrix_bd) * scaling  # (batch, head, time1, time2)
 
         attn_output_weights = attn_output_weights.view(bsz * num_heads, tgt_len, -1)
 


### PR DESCRIPTION
<!--StartFragment-->
&nbsp; | test-clean 
-- | -- 
baseline no rescore | 4.18 | 8.48
4-gram lm n-best rescore | 4.27(n=1000)
4-gram lm lattice rescore | 3.67 
<!--EndFragment-->

```
format of followig three-line score
no-rescore
n-best rescore: n =1000
lattice-rescore

epoch 30, no average:
output-beam-size 8:
2021-05-29 21:16:00,188 INFO [common.py:380] [test-clean] %WER 4.24% [2228 / 52576, 309 ins, 172 del, 1747 sub ]
2021-05-29 21:25:43,312 INFO [common.py:380] [test-clean] %WER 4.37% [2299 / 52576, 649 ins, 74 del, 1576 sub ]
2021-05-29 21:11:19,485 INFO [common.py:380] [test-clean] %WER 3.82% [2009 / 52576, 397 ins, 102 del, 1510 sub ]

output-beam-size 20:
2021-05-29 21:30:45,323 INFO [common.py:380] [test-clean] %WER 4.61% [2422 / 52576, 765 ins, 70 del, 1587 sub ]


with avg of epoch(5-19)
2021-05-29 10:56:33,837 INFO [common.py:380] [test-clean] %WER 4.18% [2196 / 52576, 253 ins, 204 del, 1739 sub ]
2021-05-29 11:05:42,011 INFO [common.py:380] [test-clean] %WER 4.27% [2247 / 52576, 613 ins, 83 del, 1551 sub ]
2021-05-29 11:02:28,304 INFO [common.py:380] [test-clean] %WER 3.67% [1932 / 52576, 333 ins, 126 del, 1473 sub ]

with avg of epoch(4-19)
2021-05-29 11:09:49,398 INFO [common.py:380] [test-clean] %WER 4.17% [2191 / 52576, 255 ins, 187 del, 1749 sub ]
2021-05-29 11:19:14,436 INFO [common.py:380] [test-clean] %WER 4.17% [2191 / 52576, 590 ins, 78 del, 1523 sub ]
2021-05-29 11:15:56,589 INFO [common.py:380] [test-clean] %WER 3.64% [1915 / 52576, 330 ins, 108 del, 1477 sub ]
```

lattice rescore with averaging different models
```
avg(4-29)
2021-05-29 11:45:22,937 INFO [common.py:380] [test-clean] %WER 3.61% [1899 / 52576, 328 ins, 101 del, 1470 sub ]
avg(4-30)
2021-05-29 11:53:21,700 INFO [common.py:380] [test-clean] %WER 3.59% [1887 / 52576, 331 ins, 101 del, 1455 sub ]
avg(1-30)
2021-05-29 12:08:18,920 INFO [common.py:380] [test-clean] %WER 3.70% [1943 / 52576, 350 ins, 107 del, 1486 sub ]
``` 